### PR TITLE
Defer not progressing check

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -82,6 +82,10 @@ func TestImagePullBackOff(t *testing.T) {
 	assertRolloutFailure(t, `Container "main" is in "ImagePullBackOff": Back-off pulling image "bogus-image:does-not-exist"`)
 }
 
+func TestImagePullBackOffOld(t *testing.T) {
+	assertRolloutFailure(t, `Container "main" is in "ImagePullBackOff": Back-off pulling image "bogus-image:does-not-exist"`)
+}
+
 func TestConfigError(t *testing.T) {
 	assertRolloutFailure(t, `Container "main" is in "CreateContainerConfigError": configmap "missing-config" not found`)
 }

--- a/tests/assets/TestImagePullBackOffOld/deployments.yaml
+++ b/tests/assets/TestImagePullBackOffOld/deployments.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    annotations:
+      deployment.kubernetes.io/revision: "1"
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"labels":{"app":"invalid-image"},"name":"invalid-image","namespace":"default"},"spec":{"progressDeadlineSeconds":30,"replicas":1,"selector":{"matchLabels":{"app":"invalid-image"}},"template":{"metadata":{"labels":{"app":"invalid-image"}},"spec":{"containers":[{"image":"bogus-image:does-not-exist","name":"main"}]}}}}
+    creationTimestamp: "2020-05-06T07:07:42Z"
+    generation: 2
+    labels:
+      app: invalid-image
+    name: invalid-image
+    namespace: default
+    resourceVersion: "92911"
+    selfLink: /apis/apps/v1/namespaces/default/deployments/invalid-image
+    uid: 8ac6c5ce-c529-4877-a8c5-2be294b6545f
+  spec:
+    progressDeadlineSeconds: 30
+    replicas: 1
+    revisionHistoryLimit: 10
+    selector:
+      matchLabels:
+        app: invalid-image
+    strategy:
+      rollingUpdate:
+        maxSurge: 25%
+        maxUnavailable: 25%
+      type: RollingUpdate
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          app: invalid-image
+      spec:
+        containers:
+        - image: bogus-image:does-not-exist
+          imagePullPolicy: IfNotPresent
+          name: main
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+  status:
+    conditions:
+    - lastTransitionTime: "2020-05-06T07:07:42Z"
+      lastUpdateTime: "2020-05-06T07:07:42Z"
+      message: Deployment does not have minimum availability.
+      reason: MinimumReplicasUnavailable
+      status: "False"
+      type: Available
+    - lastTransitionTime: "2020-05-06T07:08:13Z"
+      lastUpdateTime: "2020-05-06T07:08:13Z"
+      message: ReplicaSet "invalid-image-5bf67fdb6b" has timed out progressing.
+      reason: ProgressDeadlineExceeded
+      status: "False"
+      type: Progressing
+    observedGeneration: 2
+    replicas: 1
+    unavailableReplicas: 1
+    updatedReplicas: 1
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/tests/assets/TestImagePullBackOffOld/pods.yaml
+++ b/tests/assets/TestImagePullBackOffOld/pods.yaml
@@ -1,0 +1,103 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    creationTimestamp: "2020-05-06T07:07:42Z"
+    generateName: invalid-image-5bf67fdb6b-
+    labels:
+      app: invalid-image
+      pod-template-hash: 5bf67fdb6b
+    name: invalid-image-5bf67fdb6b-wqctx
+    namespace: default
+    ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: ReplicaSet
+      name: invalid-image-5bf67fdb6b
+      uid: 75be6aa0-33f3-4cc1-89e9-0ac7db5e32d7
+    resourceVersion: "93031"
+    selfLink: /api/v1/namespaces/default/pods/invalid-image-5bf67fdb6b-wqctx
+    uid: d3564754-1bc1-4d39-bd7a-b3b4acde4bf7
+  spec:
+    containers:
+    - image: bogus-image:does-not-exist
+      imagePullPolicy: IfNotPresent
+      name: main
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+      - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        name: default-token-7bshj
+        readOnly: true
+    dnsPolicy: ClusterFirst
+    enableServiceLinks: true
+    nodeName: minikube
+    priority: 0
+    restartPolicy: Always
+    schedulerName: default-scheduler
+    securityContext: {}
+    serviceAccount: default
+    serviceAccountName: default
+    terminationGracePeriodSeconds: 30
+    tolerations:
+    - effect: NoExecute
+      key: node.kubernetes.io/not-ready
+      operator: Exists
+      tolerationSeconds: 300
+    - effect: NoExecute
+      key: node.kubernetes.io/unreachable
+      operator: Exists
+      tolerationSeconds: 300
+    volumes:
+    - name: default-token-7bshj
+      secret:
+        defaultMode: 420
+        secretName: default-token-7bshj
+  status:
+    conditions:
+    - lastProbeTime: null
+      lastTransitionTime: "2020-05-06T07:07:42Z"
+      status: "True"
+      type: Initialized
+    - lastProbeTime: null
+      lastTransitionTime: "2020-05-06T07:07:42Z"
+      message: 'containers with unready status: [main]'
+      reason: ContainersNotReady
+      status: "False"
+      type: Ready
+    - lastProbeTime: null
+      lastTransitionTime: "2020-05-06T07:07:42Z"
+      message: 'containers with unready status: [main]'
+      reason: ContainersNotReady
+      status: "False"
+      type: ContainersReady
+    - lastProbeTime: null
+      lastTransitionTime: "2020-05-06T07:07:42Z"
+      status: "True"
+      type: PodScheduled
+    containerStatuses:
+    - image: bogus-image:does-not-exist
+      imageID: ""
+      lastState: {}
+      name: main
+      ready: false
+      restartCount: 0
+      started: false
+      state:
+        waiting:
+          message: Back-off pulling image "bogus-image:does-not-exist"
+          reason: ImagePullBackOff
+    hostIP: 192.168.99.100
+    phase: Pending
+    podIP: 172.17.0.4
+    podIPs:
+    - ip: 172.17.0.4
+    qosClass: BestEffort
+    startTime: "2020-05-06T07:07:42Z"
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/tests/assets/TestImagePullBackOffOld/replicasets.yaml
+++ b/tests/assets/TestImagePullBackOffOld/replicasets.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+items:
+- apiVersion: apps/v1
+  kind: ReplicaSet
+  metadata:
+    annotations:
+      deployment.kubernetes.io/desired-replicas: "1"
+      deployment.kubernetes.io/max-replicas: "2"
+      deployment.kubernetes.io/revision: "1"
+    creationTimestamp: "2020-05-06T07:07:42Z"
+    generation: 1
+    labels:
+      app: invalid-image
+      pod-template-hash: 5bf67fdb6b
+    name: invalid-image-5bf67fdb6b
+    namespace: default
+    ownerReferences:
+    - apiVersion: apps/v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Deployment
+      name: invalid-image
+      uid: 8ac6c5ce-c529-4877-a8c5-2be294b6545f
+    resourceVersion: "92854"
+    selfLink: /apis/apps/v1/namespaces/default/replicasets/invalid-image-5bf67fdb6b
+    uid: 75be6aa0-33f3-4cc1-89e9-0ac7db5e32d7
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: invalid-image
+        pod-template-hash: 5bf67fdb6b
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          app: invalid-image
+          pod-template-hash: 5bf67fdb6b
+      spec:
+        containers:
+        - image: bogus-image:does-not-exist
+          imagePullPolicy: IfNotPresent
+          name: main
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        schedulerName: default-scheduler
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+  status:
+    fullyLabeledReplicas: 1
+    observedGeneration: 1
+    replicas: 1
+kind: List
+metadata:
+  resourceVersion: ""
+  selfLink: ""

--- a/tests/manifests/invalid-image.yaml
+++ b/tests/manifests/invalid-image.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: invalid-image
 spec:
+  progressDeadlineSeconds: 30
   replicas: 1
   selector:
     matchLabels:


### PR DESCRIPTION
Closes #5

It makes the check slightly slower, but reports actionable errors. Unless `progressDeadlineSeconds` is set to a very low value (assuming <5 secs), rollout-status would catch the original error anyway. This patch mostly fixes situations when rollout-status was invoked on an already broken deployment (such as CI/CD job retry with invalid-image). And in that situation we don't mind spending additional few hundred milliseconds on getting the proper error message.